### PR TITLE
docs: update CLAUDE.md with new table grant requirements and add migration to revoke default privileges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm run db:types` - Regenerate TypeScript types after schema changes
 - Never edit already-applied migration files — always create a new one
 - Migration files live in `apps/web/supabase/migrations/`
+- Any new table in `public` must include explicit `grant` statements for the API roles that need access (typically `authenticated` and `service_role`; avoid granting to `anon` unless the table is intentionally public), plus `alter table … enable row level security` and policies. `supabase db diff` emits the grants automatically; hand-written migrations must include them. Default privileges for `public` are revoked, so a missing grant returns `42501` from supabase-js.
 
 ## Architecture
 

--- a/apps/web/supabase/migrations/20260515172710_revoke_default_privileges.sql
+++ b/apps/web/supabase/migrations/20260515172710_revoke_default_privileges.sql
@@ -1,0 +1,6 @@
+-- Match the future Supabase default (rolling out Oct 30, 2026): new tables in
+-- `public` no longer auto-grant access to API roles. Forces every new table to
+-- declare explicit grants, so a missing grant fails loudly in local dev with
+-- 42501 rather than silently shipping and breaking after the rollout.
+alter default privileges for role postgres in schema public
+  revoke select, insert, update, delete on tables from anon, authenticated, service_role;


### PR DESCRIPTION
update CLAUDE.md with new table grant requirements and add migration to revoke default privileges

- Added guidance for explicit grant statements for new tables in the public schema.
- Introduced a new migration to revoke default privileges for API roles on new tables, aligning with future Supabase defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated schema migration guidance with comprehensive instructions on table creation, access control configuration, and API role permission management for various deployment scenarios.

* **Chores**
  * Applied database privilege configuration updates to standardize access patterns and maintain consistency with infrastructure best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alexmarqs/tech-companies-portugal-app/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->