### PR TITLE
fix(category): strip corrupted emoji from prerendered route params

### DIFF
--- a/apps/web/src/app/category/[category]/opengraph-image.tsx
+++ b/apps/web/src/app/category/[category]/opengraph-image.tsx
@@ -1,6 +1,6 @@
 import { OgLayout, PageContent, getLogoSrc } from "@/lib/og/components";
 import { OG_CONTENT_TYPE, OG_SIZE, loadOgFonts } from "@/lib/og/utils";
-import { normalizeText } from "@/lib/utils";
+import { decodeCategoryParam, normalizeText } from "@/lib/utils";
 import { ImageResponse } from "next/og";
 
 // force generation on demand for paths not known at build time
@@ -22,7 +22,7 @@ export default async function Image({
   params: Promise<{ category: string }>;
 }) {
   const { category: categoryParam } = await params;
-  const category = decodeURIComponent(categoryParam);
+  const category = decodeCategoryParam(categoryParam);
 
   const title = `${category} Companies`;
   const description = `Discover tech companies in the ${normalizeText(category)} sector. Find job opportunities and connect with tech companies in Portugal.`;

--- a/apps/web/src/app/category/[category]/page.tsx
+++ b/apps/web/src/app/category/[category]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/metadata";
 import { getParsedCompaniesData } from "@/lib/parser/companies";
 import type { NextParams } from "@/lib/types";
-import { normalizeText } from "@/lib/utils";
+import { decodeCategoryParam, normalizeText } from "@/lib/utils";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
@@ -27,7 +27,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { category: categoryParam } = await params;
 
-  const category = decodeURIComponent(categoryParam);
+  const category = decodeCategoryParam(categoryParam);
 
   const title = `${category} Companies | Tech Companies Portugal`;
   const description = `Discover tech companies in the ${category} sector. Find job opportunities and connect with ${category} tech companies in Portugal.`;
@@ -72,7 +72,7 @@ export default async function CategoryPage({
 }) {
   const { category: categoryParam } = await params;
 
-  const category = decodeURIComponent(categoryParam);
+  const category = decodeCategoryParam(categoryParam);
 
   const normalizedCategory = normalizeText(category);
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -41,3 +41,14 @@ export const normalizeText = (text: string) => {
   // this will remove all special characters and spaces
   return text.replace(/[^a-zA-Z0-9\s]/g, "");
 };
+
+// Some emoji get corrupted to "?" / "�" in prerendered route params (a Next
+// 16.3-preview bug that splits a surrogate pair, e.g. "…Broad 💫" → "…Broad ??").
+// Decode and strip those artifacts so display and category matching still work.
+// TODO: temporary workaround — this goes away once categories move to proper
+// SEO slugs (ASCII, no emoji in the URL) instead of the raw category name.
+export const decodeCategoryParam = (categoryParam: string) =>
+  decodeURIComponent(categoryParam)
+    .replace(/[?�]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();


### PR DESCRIPTION
A Next 16.3-preview bug splits some emoji surrogate pairs in prerendered dynamic route params, replacing the halves with "?" / "�" (e.g. "Consultancy 👨‍💼 Broad 💫" → "…Broad ??"). This broke the category page: the title/heading rendered "??" and substring matching returned 0 companies.

Add decodeCategoryParam() to decode and strip those artifacts, and use it in the category page and OG image in place of bare decodeURIComponent. Company matching works again (cleaned name is a prefix of the real category) and the label no longer shows "??".

Temporary workaround until categories move to proper ASCII SEO slugs. Sitemap and footer URLs are unchanged (they encode the real category name from data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved category page links and metadata handling so category names are decoded more consistently.
  * Fixed display issues caused by malformed characters or extra spacing in category URLs.
  * Category pages and preview images now use the same cleaned-up category value for more reliable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->